### PR TITLE
Pass digest 'sha1' to crypto.pbkdf2 to support node >= 6.0

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -68,7 +68,7 @@ module.exports = function(options) {
   }
 
   function hash(data, salt, cb) {
-    crypto.pbkdf2(data, salt, HASH_ITERATIONS, HASH_LENGTH, function(err, hash) {
+    crypto.pbkdf2(data, salt, HASH_ITERATIONS, HASH_LENGTH, 'sha1', function(err, hash) {
       if (err) {
         cb(err);
         return;


### PR DESCRIPTION
Previously the digest was not explicitly required, defaulting to `sha1`, which is what is used in user-management. To allow for node versions >= 6.0, I added the `sha1` parameter explicitly.